### PR TITLE
feat: work item attachments + PR thread comments

### DIFF
--- a/src/Viamus.Azure.Devops.Mcp.Server/Models/WorkItemAttachmentContentDto.cs
+++ b/src/Viamus.Azure.Devops.Mcp.Server/Models/WorkItemAttachmentContentDto.cs
@@ -1,0 +1,19 @@
+namespace Viamus.Azure.Devops.Mcp.Server.Models;
+
+/// <summary>
+/// Data transfer object representing the downloaded content of a work item attachment.
+/// </summary>
+public sealed record WorkItemAttachmentContentDto
+{
+    public Guid Id { get; init; }
+    public string? FileName { get; init; }
+    public long Size { get; init; }
+
+    /// <summary>UTF-8 text when <see cref="IsBinary"/> is false; base64-encoded bytes otherwise.</summary>
+    public string? Content { get; init; }
+
+    /// <summary>"utf-8" or "base64".</summary>
+    public string? Encoding { get; init; }
+
+    public bool IsBinary { get; init; }
+}

--- a/src/Viamus.Azure.Devops.Mcp.Server/Models/WorkItemAttachmentDto.cs
+++ b/src/Viamus.Azure.Devops.Mcp.Server/Models/WorkItemAttachmentDto.cs
@@ -1,0 +1,15 @@
+namespace Viamus.Azure.Devops.Mcp.Server.Models;
+
+/// <summary>
+/// Data transfer object representing a file attached to a work item.
+/// </summary>
+public sealed record WorkItemAttachmentDto
+{
+    public Guid? Id { get; init; }
+    public string? Name { get; init; }
+    public long? Size { get; init; }
+    public string? Comment { get; init; }
+    public DateTime? CreatedDate { get; init; }
+    public DateTime? ModifiedDate { get; init; }
+    public string? Url { get; init; }
+}

--- a/src/Viamus.Azure.Devops.Mcp.Server/Services/AzureDevOpsService.cs
+++ b/src/Viamus.Azure.Devops.Mcp.Server/Services/AzureDevOpsService.cs
@@ -504,6 +504,204 @@ public sealed class AzureDevOpsService : IAzureDevOpsService, IDisposable
         }
     }
 
+    public async Task<IReadOnlyList<WorkItemAttachmentDto>> GetWorkItemAttachmentsAsync(
+        int workItemId,
+        string? project = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            _logger.LogDebug("Getting attachments for work item {WorkItemId}", workItemId);
+
+            var workItem = await _witClient.GetWorkItemAsync(
+                project: project ?? _options.DefaultProject,
+                id: workItemId,
+                expand: WorkItemExpand.Relations,
+                cancellationToken: cancellationToken);
+
+            if (workItem.Relations is null || workItem.Relations.Count == 0)
+            {
+                return [];
+            }
+
+            var attachments = new List<WorkItemAttachmentDto>();
+
+            foreach (var relation in workItem.Relations)
+            {
+                if (!string.Equals(relation.Rel, "AttachedFile", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                attachments.Add(MapToAttachmentDto(relation));
+            }
+
+            return attachments;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting attachments for work item {WorkItemId}", workItemId);
+            throw;
+        }
+    }
+
+    public async Task<WorkItemAttachmentContentDto?> GetWorkItemAttachmentContentAsync(
+        Guid attachmentId,
+        string? fileName = null,
+        string? project = null,
+        long maxBytes = 10 * 1024 * 1024,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            _logger.LogDebug("Downloading attachment {AttachmentId}", attachmentId);
+
+            using var stream = await _witClient.GetAttachmentContentAsync(
+                project: project ?? _options.DefaultProject,
+                id: attachmentId,
+                cancellationToken: cancellationToken);
+
+            if (stream is null)
+            {
+                return null;
+            }
+
+            var bytes = await ReadStreamWithLimitAsync(stream, maxBytes, cancellationToken);
+            var isBinary = LooksBinary(bytes);
+
+            return new WorkItemAttachmentContentDto
+            {
+                Id = attachmentId,
+                FileName = fileName,
+                Size = bytes.LongLength,
+                IsBinary = isBinary,
+                Encoding = isBinary ? "base64" : "utf-8",
+                Content = isBinary ? Convert.ToBase64String(bytes) : System.Text.Encoding.UTF8.GetString(bytes)
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error downloading attachment {AttachmentId}", attachmentId);
+            throw;
+        }
+    }
+
+    private static async Task<byte[]> ReadStreamWithLimitAsync(Stream stream, long maxBytes, CancellationToken cancellationToken)
+    {
+        using var ms = new MemoryStream();
+        var buffer = new byte[81920];
+        long total = 0;
+
+        while (true)
+        {
+            var read = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken);
+            if (read == 0)
+            {
+                break;
+            }
+
+            total += read;
+            if (total > maxBytes)
+            {
+                throw new InvalidOperationException(
+                    $"Attachment exceeds the {maxBytes:N0}-byte limit. Use the URL from get_work_item_attachments to download it directly.");
+            }
+
+            ms.Write(buffer, 0, read);
+        }
+
+        return ms.ToArray();
+    }
+
+    private static bool LooksBinary(byte[] bytes)
+    {
+        var sample = Math.Min(bytes.Length, 8000);
+        for (var i = 0; i < sample; i++)
+        {
+            if (bytes[i] == 0)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static WorkItemAttachmentDto MapToAttachmentDto(WorkItemRelation relation)
+    {
+        var attributes = relation.Attributes;
+
+        string? name = null;
+        long? size = null;
+        string? comment = null;
+        DateTime? createdDate = null;
+        DateTime? modifiedDate = null;
+
+        if (attributes != null)
+        {
+            if (attributes.TryGetValue("name", out var nameValue))
+            {
+                name = nameValue?.ToString();
+            }
+
+            if (attributes.TryGetValue("resourceSize", out var sizeValue) && sizeValue != null)
+            {
+                size = Convert.ToInt64(sizeValue);
+            }
+
+            if (attributes.TryGetValue("comment", out var commentValue))
+            {
+                comment = commentValue?.ToString();
+            }
+
+            if (attributes.TryGetValue("resourceCreatedDate", out var createdValue)
+                && DateTime.TryParse(createdValue?.ToString(), out var parsedCreated))
+            {
+                createdDate = parsedCreated;
+            }
+
+            if (attributes.TryGetValue("resourceModifiedDate", out var modifiedValue)
+                && DateTime.TryParse(modifiedValue?.ToString(), out var parsedModified))
+            {
+                modifiedDate = parsedModified;
+            }
+        }
+
+        return new WorkItemAttachmentDto
+        {
+            Id = ExtractAttachmentId(relation.Url),
+            Name = name,
+            Size = size,
+            Comment = comment,
+            CreatedDate = createdDate,
+            ModifiedDate = modifiedDate,
+            Url = relation.Url
+        };
+    }
+
+    private static Guid? ExtractAttachmentId(string? url)
+    {
+        if (string.IsNullOrEmpty(url))
+        {
+            return null;
+        }
+
+        // URL format: https://{host}/{org}/{project}/_apis/wit/attachments/{guid}[?...]
+        var lastSlash = url.LastIndexOf('/');
+        if (lastSlash < 0 || lastSlash == url.Length - 1)
+        {
+            return null;
+        }
+
+        var idPart = url[(lastSlash + 1)..];
+        var queryStart = idPart.IndexOf('?');
+        if (queryStart >= 0)
+        {
+            idPart = idPart[..queryStart];
+        }
+
+        return Guid.TryParse(idPart, out var id) ? id : null;
+    }
+
     public async Task<WorkItemDto> CreateWorkItemAsync(
         string project,
         string workItemType,
@@ -1139,6 +1337,60 @@ public sealed class AzureDevOpsService : IAzureDevOpsService, IDisposable
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting threads for pull request {PullRequestId}", pullRequestId);
+            throw;
+        }
+    }
+
+    public async Task<PullRequestCommentDto> AddPullRequestThreadCommentAsync(
+        string repositoryNameOrId,
+        int pullRequestId,
+        int threadId,
+        string content,
+        int? parentCommentId = null,
+        string? project = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var projectName = project ?? _options.DefaultProject;
+            _logger.LogDebug(
+                "Adding comment to thread {ThreadId} on pull request {PullRequestId}",
+                threadId,
+                pullRequestId);
+
+            var comment = new Microsoft.TeamFoundation.SourceControl.WebApi.Comment
+            {
+                Content = content,
+                ParentCommentId = parentCommentId.HasValue ? (short)parentCommentId.Value : (short)0,
+                CommentType = CommentType.Text
+            };
+
+            var created = await _gitClient.CreateCommentAsync(
+                comment: comment,
+                repositoryId: repositoryNameOrId,
+                pullRequestId: pullRequestId,
+                threadId: threadId,
+                project: projectName,
+                cancellationToken: cancellationToken);
+
+            return new PullRequestCommentDto
+            {
+                Id = created.Id,
+                ParentCommentId = created.ParentCommentId,
+                Content = created.Content,
+                Author = created.Author?.DisplayName,
+                PublishedDate = created.PublishedDate,
+                LastUpdatedDate = created.LastUpdatedDate,
+                CommentType = created.CommentType.ToString()
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Error adding comment to thread {ThreadId} on pull request {PullRequestId}",
+                threadId,
+                pullRequestId);
             throw;
         }
     }

--- a/src/Viamus.Azure.Devops.Mcp.Server/Services/IAzureDevOpsService.cs
+++ b/src/Viamus.Azure.Devops.Mcp.Server/Services/IAzureDevOpsService.cs
@@ -76,6 +76,34 @@ public interface IAzureDevOpsService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Gets the attachments linked to a work item.
+    /// </summary>
+    /// <param name="workItemId">The work item ID.</param>
+    /// <param name="project">The project name (optional if default project is configured).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of attachments (filename, size, URL, timestamps).</returns>
+    Task<IReadOnlyList<WorkItemAttachmentDto>> GetWorkItemAttachmentsAsync(
+        int workItemId,
+        string? project = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Downloads the content of a work item attachment by its ID and returns it inline.
+    /// </summary>
+    /// <param name="attachmentId">The attachment GUID (from <see cref="GetWorkItemAttachmentsAsync"/>).</param>
+    /// <param name="fileName">Optional filename, used in the response.</param>
+    /// <param name="project">The project name (optional if default project is configured).</param>
+    /// <param name="maxBytes">Maximum bytes to download (default 10 MB). Larger attachments throw.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Attachment content as UTF-8 text or base64 bytes.</returns>
+    Task<WorkItemAttachmentContentDto?> GetWorkItemAttachmentContentAsync(
+        Guid attachmentId,
+        string? fileName = null,
+        string? project = null,
+        long maxBytes = 10 * 1024 * 1024,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Creates a new work item in the specified project.
     /// </summary>
     /// <param name="project">The project name.</param>
@@ -266,6 +294,26 @@ public interface IAzureDevOpsService
     Task<IReadOnlyList<PullRequestThreadDto>> GetPullRequestThreadsAsync(
         string repositoryNameOrId,
         int pullRequestId,
+        string? project = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Adds a comment to an existing comment thread on a pull request.
+    /// </summary>
+    /// <param name="repositoryNameOrId">The repository name or ID.</param>
+    /// <param name="pullRequestId">The pull request ID.</param>
+    /// <param name="threadId">The thread ID to comment on.</param>
+    /// <param name="content">The comment text (Markdown supported).</param>
+    /// <param name="parentCommentId">Optional parent comment ID when replying to a specific comment.</param>
+    /// <param name="project">The project name (optional if default project is configured).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The created comment.</returns>
+    Task<PullRequestCommentDto> AddPullRequestThreadCommentAsync(
+        string repositoryNameOrId,
+        int pullRequestId,
+        int threadId,
+        string content,
+        int? parentCommentId = null,
         string? project = null,
         CancellationToken cancellationToken = default);
 

--- a/src/Viamus.Azure.Devops.Mcp.Server/Tools/PullRequestTools.cs
+++ b/src/Viamus.Azure.Devops.Mcp.Server/Tools/PullRequestTools.cs
@@ -136,6 +136,49 @@ public sealed class PullRequestTools
         }, JsonOptions);
     }
 
+    [McpServerTool(Name = "add_pull_request_thread_comment")]
+    [Description("Adds a comment to an existing comment thread on a pull request. Use this to reply to discussions returned by get_pull_request_threads. Pass parentCommentId to reply to a specific comment within the thread; omit it to add a top-level comment.")]
+    public async Task<string> AddPullRequestThreadComment(
+        [Description("The repository name or ID")] string repositoryNameOrId,
+        [Description("The pull request ID")] int pullRequestId,
+        [Description("The thread ID (from get_pull_request_threads)")] int threadId,
+        [Description("The comment text (Markdown supported)")] string content,
+        [Description("Optional parent comment ID when replying to a specific comment in the thread")] int? parentCommentId = null,
+        [Description("The project name (optional if default project is configured)")] string? project = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(repositoryNameOrId))
+        {
+            return JsonSerializer.Serialize(new { error = "Repository name or ID is required" }, JsonOptions);
+        }
+
+        if (pullRequestId <= 0)
+        {
+            return JsonSerializer.Serialize(new { error = "Pull request ID must be a positive integer" }, JsonOptions);
+        }
+
+        if (threadId <= 0)
+        {
+            return JsonSerializer.Serialize(new { error = "Thread ID must be a positive integer" }, JsonOptions);
+        }
+
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            return JsonSerializer.Serialize(new { error = "Comment content cannot be empty" }, JsonOptions);
+        }
+
+        var comment = await _azureDevOpsService.AddPullRequestThreadCommentAsync(
+            repositoryNameOrId, pullRequestId, threadId, content,
+            parentCommentId, project, cancellationToken);
+
+        return JsonSerializer.Serialize(new
+        {
+            success = true,
+            message = $"Comment added to thread {threadId} on pull request {pullRequestId}",
+            comment
+        }, JsonOptions);
+    }
+
     [McpServerTool(Name = "search_pull_requests")]
     [Description("Searches pull requests by text in title or description. Useful for finding PRs related to specific features or bugs.")]
     public async Task<string> SearchPullRequests(

--- a/src/Viamus.Azure.Devops.Mcp.Server/Tools/WorkItemTools.cs
+++ b/src/Viamus.Azure.Devops.Mcp.Server/Tools/WorkItemTools.cs
@@ -233,6 +233,58 @@ public sealed class WorkItemTools
         }, JsonOptions);
     }
 
+    [McpServerTool(Name = "get_work_item_attachments")]
+    [Description("Lists files attached to a work item. Returns each attachment's name, size (bytes), upload/modified dates, optional comment, and download URL. Authenticate with the same PAT to fetch the binary content from the URL.")]
+    public async Task<string> GetWorkItemAttachments(
+        [Description("The ID of the work item")] int workItemId,
+        [Description("The project name (optional if default project is configured)")] string? project = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (workItemId <= 0)
+        {
+            return JsonSerializer.Serialize(new { error = "Work item ID must be a positive integer" }, JsonOptions);
+        }
+
+        var attachments = await _azureDevOpsService.GetWorkItemAttachmentsAsync(workItemId, project, cancellationToken);
+
+        return JsonSerializer.Serialize(new
+        {
+            workItemId,
+            count = attachments.Count,
+            attachments
+        }, JsonOptions);
+    }
+
+    [McpServerTool(Name = "get_work_item_attachment_content")]
+    [Description("Downloads the content of a work item attachment by its GUID (use get_work_item_attachments to discover GUIDs) and returns it inline. Text files come back as UTF-8; binary files as base64-encoded bytes. Refuses files larger than maxBytes (default 10 MB) — for those, use the URL from get_work_item_attachments and download out-of-band.")]
+    public async Task<string> GetWorkItemAttachmentContent(
+        [Description("The attachment GUID (e.g., '2ee06d3b-4ea4-4390-80de-474a4e1e4355')")] string attachmentId,
+        [Description("Optional original filename (echoed back in the response)")] string? fileName = null,
+        [Description("The project name (optional if default project is configured)")] string? project = null,
+        [Description("Maximum bytes to download (default 10485760 = 10 MB). Larger attachments are rejected.")] int maxBytes = 10 * 1024 * 1024,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Guid.TryParse(attachmentId, out var guid))
+        {
+            return JsonSerializer.Serialize(new { error = "attachmentId must be a valid GUID" }, JsonOptions);
+        }
+
+        if (maxBytes <= 0)
+        {
+            return JsonSerializer.Serialize(new { error = "maxBytes must be positive" }, JsonOptions);
+        }
+
+        var content = await _azureDevOpsService.GetWorkItemAttachmentContentAsync(
+            guid, fileName, project, maxBytes, cancellationToken);
+
+        if (content is null)
+        {
+            return JsonSerializer.Serialize(new { error = $"Attachment {attachmentId} not found" }, JsonOptions);
+        }
+
+        return JsonSerializer.Serialize(content, JsonOptions);
+    }
+
     [McpServerTool(Name = "add_work_item_comment")]
     [Description("Adds a comment to a specific Azure DevOps work item. Use this to add notes, updates, or feedback to a work item.")]
     public async Task<string> AddWorkItemComment(


### PR DESCRIPTION
## Summary

Closes three functional gaps in the MCP server:

- **`get_work_item_attachments`** — lists files attached to a work item: `id` (GUID), `name`, `size` (bytes), `comment`, `createdDate`, `modifiedDate`, and download `url`. Reads work item relations filtered by `Rel == "AttachedFile"`.
- **`get_work_item_attachment_content`** — downloads an attachment by GUID and returns content **inline** so it can feed Claude Code sessions directly. UTF-8 for textual files, base64 for binaries (`isBinary` + `encoding` flags). Default 10 MB cap (`maxBytes`); larger files are rejected with guidance to use the URL out-of-band.
- **`add_pull_request_thread_comment`** — replies to existing PR comment threads (the read side already existed via `get_pull_request_threads`). Accepts optional `parentCommentId` for threaded replies.

Mirrors existing service/tool patterns: validation in the tool, mapping in the service, JSON-serialized response.

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test` — 281/281 passing
- [x] Manual: `get_work_item_attachments` against work item 2413308 returned 2 attachments with correct sizes
- [x] Manual: `get_work_item_attachment_content` with binary (xlsx 10029 B → base64) and text (json 548812 B → UTF-8) attachments — content matches direct PAT download byte-for-byte
- [ ] Manual: `add_pull_request_thread_comment` against a throwaway PR thread (not yet exercised — recommend reviewer test before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)