### PR TITLE
Add pull request thread status update tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ This project implements an MCP server that exposes tools for querying and managi
 | `get_pull_request_by_id` | Gets details of a pull request by ID only, searching across all repositories in the project |
 | `get_pull_request_threads` | Gets comment threads for a pull request |
 | `create_pull_request_thread` | Creates a new comment thread on a pull request, either as a general discussion or inline file comment |
+| `update_pull_request_thread_status` | Updates a pull request comment thread status, including close/resolve aliases |
 | `search_pull_requests` | Searches pull requests by text in title or description |
 | `query_pull_requests` | Advanced query with multiple combined filters |
 | `create_pull_request` | Creates a new pull request with title, description, source/target branches, draft flag, reviewers, and linked work items |

--- a/src/Viamus.Azure.Devops.Mcp.Server/Services/AzureDevOpsService.cs
+++ b/src/Viamus.Azure.Devops.Mcp.Server/Services/AzureDevOpsService.cs
@@ -1598,6 +1598,54 @@ public sealed class AzureDevOpsService : IAzureDevOpsService, IDisposable
         }
     }
 
+    public async Task<PullRequestThreadDto> UpdatePullRequestThreadStatusAsync(
+        string repositoryNameOrId,
+        int pullRequestId,
+        int threadId,
+        string status,
+        string? project = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var projectName = project ?? _options.DefaultProject;
+            var threadStatus = ParseCommentThreadStatus(status)
+                ?? throw new ArgumentException($"Unsupported pull request thread status '{status}'", nameof(status));
+
+            _logger.LogDebug(
+                "Updating thread {ThreadId} on pull request {PullRequestId} to status {Status}",
+                threadId,
+                pullRequestId,
+                threadStatus);
+
+            var thread = new GitPullRequestCommentThread
+            {
+                Status = threadStatus
+            };
+
+            var updated = await _gitClient.UpdateThreadAsync(
+                commentThread: thread,
+                project: projectName,
+                repositoryId: repositoryNameOrId,
+                pullRequestId: pullRequestId,
+                threadId: threadId,
+                userState: null,
+                cancellationToken: cancellationToken);
+
+            return MapToPullRequestThreadDto(updated);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Error updating thread {ThreadId} on pull request {PullRequestId} to status {Status}",
+                threadId,
+                pullRequestId,
+                status);
+            throw;
+        }
+    }
+
     public async Task<IReadOnlyList<PullRequestDto>> SearchPullRequestsAsync(
         string repositoryNameOrId,
         string searchText,
@@ -1753,6 +1801,23 @@ public sealed class AzureDevOpsService : IAzureDevOpsService, IDisposable
                 HasDeclined = r.HasDeclined ?? false,
                 ImageUrl = r.ImageUrl
             }).ToList()
+        };
+    }
+
+    private static CommentThreadStatus? ParseCommentThreadStatus(string? status)
+    {
+        if (string.IsNullOrWhiteSpace(status))
+            return null;
+
+        return status.Trim().ToLowerInvariant().Replace("_", string.Empty).Replace("-", string.Empty) switch
+        {
+            "active" or "open" or "reopen" or "reopened" => CommentThreadStatus.Active,
+            "fixed" or "fix" or "resolve" or "resolved" => CommentThreadStatus.Fixed,
+            "wontfix" or "wont" => CommentThreadStatus.WontFix,
+            "closed" or "close" => CommentThreadStatus.Closed,
+            "bydesign" => CommentThreadStatus.ByDesign,
+            "pending" => CommentThreadStatus.Pending,
+            _ => null
         };
     }
 

--- a/src/Viamus.Azure.Devops.Mcp.Server/Services/IAzureDevOpsService.cs
+++ b/src/Viamus.Azure.Devops.Mcp.Server/Services/IAzureDevOpsService.cs
@@ -380,6 +380,24 @@ public interface IAzureDevOpsService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Updates the status of an existing comment thread on a pull request.
+    /// </summary>
+    /// <param name="repositoryNameOrId">The repository name or ID.</param>
+    /// <param name="pullRequestId">The pull request ID.</param>
+    /// <param name="threadId">The thread ID to update.</param>
+    /// <param name="status">The target thread status, such as Active, Fixed, Closed, WontFix, ByDesign, or Pending.</param>
+    /// <param name="project">The project name (optional if default project is configured).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The updated comment thread.</returns>
+    Task<PullRequestThreadDto> UpdatePullRequestThreadStatusAsync(
+        string repositoryNameOrId,
+        int pullRequestId,
+        int threadId,
+        string status,
+        string? project = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Searches pull requests by title or description.
     /// </summary>
     /// <param name="repositoryNameOrId">The repository name or ID.</param>

--- a/src/Viamus.Azure.Devops.Mcp.Server/Tools/PullRequestTools.cs
+++ b/src/Viamus.Azure.Devops.Mcp.Server/Tools/PullRequestTools.cs
@@ -233,6 +233,52 @@ public sealed class PullRequestTools
         }, JsonOptions);
     }
 
+    [McpServerTool(Name = "update_pull_request_thread_status")]
+    [Description("Updates the status of an existing pull request comment thread. Supports statuses/aliases such as active/open/reopen, fixed/resolve/resolved, closed/close, wontFix/wont-fix, byDesign/by-design, and pending.")]
+    public async Task<string> UpdatePullRequestThreadStatus(
+        [Description("The repository name or ID")] string repositoryNameOrId,
+        [Description("The pull request ID")] int pullRequestId,
+        [Description("The thread ID (from get_pull_request_threads)")] int threadId,
+        [Description("Target status: Active, Fixed, Closed, WontFix, ByDesign, Pending, or aliases like close/resolve")] string status,
+        [Description("The project name (optional if default project is configured)")] string? project = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(repositoryNameOrId))
+        {
+            return JsonSerializer.Serialize(new { error = "Repository name or ID is required" }, JsonOptions);
+        }
+
+        if (pullRequestId <= 0)
+        {
+            return JsonSerializer.Serialize(new { error = "Pull request ID must be a positive integer" }, JsonOptions);
+        }
+
+        if (threadId <= 0)
+        {
+            return JsonSerializer.Serialize(new { error = "Thread ID must be a positive integer" }, JsonOptions);
+        }
+
+        var normalizedStatus = NormalizeThreadStatus(status);
+        if (normalizedStatus is null)
+        {
+            return JsonSerializer.Serialize(new
+            {
+                error = "Unsupported thread status. Supported statuses are Active, Fixed, Closed, WontFix, ByDesign, and Pending. Aliases include open, reopen, resolve, resolved, close, closed, wont-fix, and by-design."
+            }, JsonOptions);
+        }
+
+        var thread = await _azureDevOpsService.UpdatePullRequestThreadStatusAsync(
+            repositoryNameOrId, pullRequestId, threadId, normalizedStatus,
+            project, cancellationToken);
+
+        return JsonSerializer.Serialize(new
+        {
+            success = true,
+            message = $"Thread {threadId} on pull request {pullRequestId} updated to {thread.Status}",
+            thread
+        }, JsonOptions);
+    }
+
     [McpServerTool(Name = "search_pull_requests")]
     [Description("Searches pull requests by text in title or description. Useful for finding PRs related to specific features or bugs.")]
     public async Task<string> SearchPullRequests(
@@ -263,6 +309,23 @@ public sealed class PullRequestTools
             count = pullRequests.Count,
             pullRequests
         }, JsonOptions);
+    }
+
+    private static string? NormalizeThreadStatus(string? status)
+    {
+        if (string.IsNullOrWhiteSpace(status))
+            return null;
+
+        return status.Trim().ToLowerInvariant().Replace("_", string.Empty).Replace("-", string.Empty) switch
+        {
+            "active" or "open" or "reopen" or "reopened" => "Active",
+            "fixed" or "fix" or "resolve" or "resolved" => "Fixed",
+            "wontfix" or "wont" => "WontFix",
+            "closed" or "close" => "Closed",
+            "bydesign" => "ByDesign",
+            "pending" => "Pending",
+            _ => null
+        };
     }
 
     [McpServerTool(Name = "create_pull_request")]

--- a/tests/Viamus.Azure.Devops.Mcp.Server.Tests/Tools/PullRequestToolsTests.cs
+++ b/tests/Viamus.Azure.Devops.Mcp.Server.Tests/Tools/PullRequestToolsTests.cs
@@ -483,6 +483,123 @@ public class PullRequestToolsTests
 
     #endregion
 
+    #region UpdatePullRequestThreadStatus Tests
+
+    [Fact]
+    public async Task UpdatePullRequestThreadStatus_ShouldUpdateStatus()
+    {
+        var thread = new PullRequestThreadDto
+        {
+            Id = 10,
+            Status = "Closed"
+        };
+
+        _mockService
+            .Setup(s => s.UpdatePullRequestThreadStatusAsync(
+                "repo",
+                123,
+                10,
+                "Closed",
+                null,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(thread);
+
+        var result = await _tools.UpdatePullRequestThreadStatus("repo", 123, 10, "close");
+
+        Assert.Contains("\"success\": true", result);
+        Assert.Contains("updated to Closed", result);
+        Assert.Contains("\"status\": \"Closed\"", result);
+        _mockService.Verify(s => s.UpdatePullRequestThreadStatusAsync(
+            "repo",
+            123,
+            10,
+            "Closed",
+            null,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdatePullRequestThreadStatus_WithResolveAlias_ShouldSendFixed()
+    {
+        var thread = new PullRequestThreadDto
+        {
+            Id = 10,
+            Status = "Fixed"
+        };
+
+        _mockService
+            .Setup(s => s.UpdatePullRequestThreadStatusAsync(
+                "repo",
+                123,
+                10,
+                "Fixed",
+                "MyProject",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(thread);
+
+        await _tools.UpdatePullRequestThreadStatus("repo", 123, 10, "resolve", "MyProject");
+
+        _mockService.Verify(s => s.UpdatePullRequestThreadStatusAsync(
+            "repo",
+            123,
+            10,
+            "Fixed",
+            "MyProject",
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdatePullRequestThreadStatus_WithEmptyRepoName_ShouldReturnError()
+    {
+        var result = await _tools.UpdatePullRequestThreadStatus("", 123, 10, "closed");
+
+        Assert.Contains("error", result);
+        Assert.Contains("Repository name or ID is required", result);
+        _mockService.Verify(s => s.UpdatePullRequestThreadStatusAsync(
+            It.IsAny<string>(),
+            It.IsAny<int>(),
+            It.IsAny<int>(),
+            It.IsAny<string>(),
+            It.IsAny<string?>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdatePullRequestThreadStatus_WithInvalidPRId_ShouldReturnError()
+    {
+        var result = await _tools.UpdatePullRequestThreadStatus("repo", 0, 10, "closed");
+
+        Assert.Contains("error", result);
+        Assert.Contains("Pull request ID must be a positive integer", result);
+    }
+
+    [Fact]
+    public async Task UpdatePullRequestThreadStatus_WithInvalidThreadId_ShouldReturnError()
+    {
+        var result = await _tools.UpdatePullRequestThreadStatus("repo", 123, 0, "closed");
+
+        Assert.Contains("error", result);
+        Assert.Contains("Thread ID must be a positive integer", result);
+    }
+
+    [Fact]
+    public async Task UpdatePullRequestThreadStatus_WithUnsupportedStatus_ShouldReturnError()
+    {
+        var result = await _tools.UpdatePullRequestThreadStatus("repo", 123, 10, "done");
+
+        Assert.Contains("error", result);
+        Assert.Contains("Unsupported thread status", result);
+        _mockService.Verify(s => s.UpdatePullRequestThreadStatusAsync(
+            It.IsAny<string>(),
+            It.IsAny<int>(),
+            It.IsAny<int>(),
+            It.IsAny<string>(),
+            It.IsAny<string?>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    #endregion
+
     #region SearchPullRequests Tests
 
     [Fact]


### PR DESCRIPTION
## Summary
- add update_pull_request_thread_status MCP tool for PR comment threads
- support close/resolve aliases and canonical Azure DevOps thread statuses
- add unit coverage and README entry

## Validation
- dotnet restore --configfile .\\NuGet.Test.Config
- dotnet test --no-restore
- docker compose up --build -d